### PR TITLE
fix: rename WBNB to WSRW for SimpleChain consistency

### DIFF
--- a/wsrw/WSRW.sol
+++ b/wsrw/WSRW.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.18;
 
-contract WBNB {
-    string public name     = "Wrapped BNB";
-    string public symbol   = "WBNB";
+contract WSRW {
+    string public name     = "Wrapped SRW";
+    string public symbol   = "WSRW";
     uint8  public decimals = 18;
 
     event  Approval(address indexed src, address indexed guy, uint wad);


### PR DESCRIPTION
## Summary
- 将 `wbnb/` 文件夹及 `WBNB.sol` 合约重命名为 `wsrw/WSRW.sol`
- 合约内部 name 和 symbol 相应更新（Wrapped BNB → Wrapped SRW，WBNB → WSRW）

## Changes
| 项 | 当前值 | 目标值 |
|----|--------|--------|
| 文件夹 | `wbnb/` | `wsrw/` |
| 文件名 | `WBNB.sol` | `WSRW.sol` |
| 合约名 | `WBNB` | `WSRW` |
| name | `"Wrapped BNB"` | `"Wrapped SRW"` |
| symbol | `"WBNB"` | `"WSRW"` |

## Test plan
- [ ] 确认合约编译通过

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)